### PR TITLE
Fixes: process files from the desktop and WIA-cmd-scanner subprocessing

### DIFF
--- a/addon/globalPlugins/tesseractOCR/__init__.py
+++ b/addon/globalPlugins/tesseractOCR/__init__.py
@@ -281,14 +281,20 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 
 	def digitalizeDocument(self):
 		# Digitalize one page from scanner
-		jpgBatPath = os.path.join(PLUGIN_DIR, "ocr.bat")
-		wiaCMDPath = os.path.join (PLUGIN_DIR, "wia-cmd-scanner")
 		# The next two lines are to prevent the cmd from being displayed.
 		si = subprocess.STARTUPINFO()
 		si.dwFlags |= subprocess.STARTF_USESHOWWINDOW
-		command = "{} cwd={}".format(jpgBatPath, wiaCMDPath)
+		command = "{exe} /w 210 /h 297 /dpi {dpi} /color {color} /format JPG /output {output} cwd={cwd}".format(
+		exe = os.path.join(PLUGIN_DIR, "wia-cmd-scanner", "wia-cmd-scanner.exe"),
+		dpi = 150,
+		color = "GRAY",
+		output = os.path.join(PLUGIN_DIR, "images", "ocr.jpg"),
+		cwd = os.path.join(PLUGIN_DIR, "wia-cmd-scanner")
+		)
 		p = Popen(command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, startupinfo=si)
 		stdout, stderr = p.communicate()
+		if stderr or stdout == b'No compatible scanners found\r\n':
+			raise RuntimeError("Subprocess wia-cmd-scanner failed:\n {error}".format(error=stderr.decode()) if stderr else stdout.decode())
 
 	def showResults(self):
 		# Opening the TXT file with OCR results.

--- a/addon/globalPlugins/tesseractOCR/__init__.py
+++ b/addon/globalPlugins/tesseractOCR/__init__.py
@@ -223,6 +223,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 				focusedItem=window.Document.FocusedItem
 				break
 		else: # loop exhausted
+			desktop_path = os.path.join(os.path.join(os.environ['USERPROFILE']), 'Desktop')
+			docPath = desktop_path + '\\' + api.getDesktopObject().objectWithFocus().name
 			return
 		# Now that we have the current folder, we can explore the SelectedItems collection.
 		targetFile= focusedItem.path
@@ -339,7 +341,7 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 		# Obtain the full path of the selected file
 		self.getDocName()
 		# Check if is a supported file, and if yes if it is PDF or image file
-		ext = docPath[-5:-1].lower()
+		ext = os.path.splitext(docPath)[-1].lower().replace(r'"', '')
 		if ext == ".pdf":
 			self._thread = threading.Thread(target = self._doRoutines)
 			self._thread.setDaemon(True)


### PR DESCRIPTION
FIX 1:
Now correctly process supported files from desktop.

FIX 2:
In the bat file you used absolute paths. Those paths are not valid on all computers; that's why it didn't work for me. I have directly called wia-cmd-scanner.exe with its arguments. Now you can do without the bat file.
I have lowered the resolution to 150; for OCR it is enough and 300 can be slow on some scanners.
I've put dpi and color as arguments in the string in case you want to give the user the option to set these parameters in the future.
I have set w and h to 0, in this way it takes the values defined by the scanner.

On the other hand, the cause of the thread staying active and never ending is later, in _doRoutines2:

		# Wait until file be put on right local
		while not  os.path.exists(jpgFilePath):
			time.sleep(0.01)

If self.digitalizeDocument() fails, the thread gets stuck in this loop.
I have added a RuntimeError exception in digitalizeDocument when the subprocess returns an error code or reports that it has not found a compatible scanner; this interrupts the thread preventing it from getting caught.
"""
